### PR TITLE
Bug/164 displayname conflict

### DIFF
--- a/distributedsocialnetwork/distributedsocialnetwork/views.py
+++ b/distributedsocialnetwork/distributedsocialnetwork/views.py
@@ -3,11 +3,13 @@ from author.models import Author
 from post.models import Post
 from friend.models import Friend
 from django.conf import settings
+from post.retrieval import get_public_posts
 
 
 def index(request):
     context = {}
     # We only want the authors from our server to be featured in the "featured authors" section
+    get_public_posts()
     authors = Author.objects.filter(
         host=settings.FORMATTED_HOST_NAME, is_node=False, is_staff=False)
     context['authors'] = authors

--- a/distributedsocialnetwork/post/templates/detailed_post.html
+++ b/distributedsocialnetwork/post/templates/detailed_post.html
@@ -52,7 +52,7 @@
           {% endif %}
         </div>
         <div class="card-footer text-muted text-right p-2">
-          <p class="m-0">{{ post.author.first_name }} {{ post.author.last_name }}</p>
+          <p class="m-0">{{ post.author.displayName }}</p>
           <p class="small m-0">{{ post.published }}</p>
         </div>
       </div>
@@ -74,7 +74,7 @@
           {% endif %}
         </div>
         <div class="card-footer text-muted text-right p-2">
-          <p class="m-0">{{ comment.author.first_name }} {{ comment.author.last_name }}</p>
+          <p class="m-0">{{ comment.author.displayName }}</p>
           <p class="small m-0">{{ comment.published }}</p>
         </div>
       </div>

--- a/distributedsocialnetwork/templates/index.html
+++ b/distributedsocialnetwork/templates/index.html
@@ -54,7 +54,7 @@
         {% endif %}
       </div>
       <div class="card-footer text-muted text-right p-2">
-        <p class="m-0">{{ post.author.first_name }} {{ post.author.last_name }}</p>
+        <a href="{{post.author.url}}"><p class="m-0">{{ post.author.displayName }}</p></a>
         <p class="small m-0">{{ post.published }}</p>
       </div>
     </div>


### PR DESCRIPTION
- When an author is generated from the foreign server we assign it a new display name (foreignName (NodeIt is From))
- When an author is generated from the foreign server we also set a new "url" to point to the local version
- When a post is generated from the foreign server we set the post source to a local url 