### PR TITLE
Add 'Explore' tab to homepage

### DIFF
--- a/distributedsocialnetwork/api/urls.py
+++ b/distributedsocialnetwork/api/urls.py
@@ -14,11 +14,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.urls import path
-from .views import PostDetailView, CommentList, VisiblePosts, AuthUserPosts, AuthorPosts, AuthorFriendsList, AreAuthorsFriends, FriendRequest, AuthorDetail
+from .views import PostDetailView, CommentList, VisiblePosts, ForeignPosts, AuthUserPosts, AuthorPosts, AuthorFriendsList, AreAuthorsFriends, FriendRequest, AuthorDetail
 
 
 urlpatterns = [
     path('posts', VisiblePosts.as_view(), name='public-posts'),
+    path('posts/foreign', ForeignPosts.as_view(), name='foreign-posts'),
     path('posts/<uuid:pk>', PostDetailView.as_view(), name="posts-detail"),
     path('posts/<uuid:pk>/comments',
          CommentList.as_view(), name="comments-list"),

--- a/distributedsocialnetwork/api/views.py
+++ b/distributedsocialnetwork/api/views.py
@@ -10,7 +10,7 @@ from post.serializers import PostSerializer, CommentSerializer
 from author.serializers import AuthorSerializer
 from django.core.paginator import Paginator
 from django.urls import reverse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 import urllib
 from django.conf import settings
 
@@ -148,6 +148,18 @@ class VisiblePosts(APIView):
             post["comments"] = comment_list_dict["comments"]
         response["posts"] = post_list_dict["posts"]
         return Response(response)
+
+# ====== /api/posts/foreign/ ======
+
+class ForeignPosts(APIView):
+    # Retrieves all posts not originating from this server.
+    # Returned as HTML for simple front-end integration.
+    def get(self, request):
+        posts = Post.objects.filter(visibility="PUBLIC").exclude(
+            origin__icontains=settings.FORMATTED_HOST_NAME)
+        context = {}
+        context["posts"] = posts
+        return render(request, 'stream.html', context)
 
 # ====== /api/posts/<post_id> ======
 

--- a/distributedsocialnetwork/distributedsocialnetwork/static/distributedsocialnetwork/styles.css
+++ b/distributedsocialnetwork/distributedsocialnetwork/static/distributedsocialnetwork/styles.css
@@ -19,8 +19,21 @@
   background-color: var(--primary-color);
 }
 
+#tabs {
+  padding-top: 0em;
+  background-color: white;
+}
+
 .nav-link {
   color: var(--accent-color);
+}
+
+.nav-link h2 {
+  color: gray;
+}
+
+.nav-link.active h2 {
+  color: var(--primary-color);
 }
 
 .btn-outline-primary,
@@ -46,6 +59,7 @@ a {
 .stream {
   background-color: white;
   padding-top: 0.5rem;
+  min-height: 90vh;
 }
 
 .sidebar {
@@ -65,10 +79,6 @@ a {
 
 .featured-author > .card-body {
   padding: 0.5rem;
-}
-
-#stream {
-  min-height: 90vh;
 }
 
 footer {

--- a/distributedsocialnetwork/templates/base.html
+++ b/distributedsocialnetwork/templates/base.html
@@ -32,7 +32,7 @@
 
 <body class="container-fluid m-0 p-0">
 	<header class="header">
-		<img class="logo" width="64px" src="{% static "distributedsocialnetwork/DSN-404.png" %}" alt="DSN logo">
+		<a href="{% url 'home' %}"><img class="logo" width="64px" src="{% static "distributedsocialnetwork/DSN-404.png" %}" alt="DSN logo"></a>
 		<ul class="nav nav-tabs justify-content-end">
 			<!-- Use template inheritance to customize navigation, https://stackoverflow.com/a/341748 -->
 			<li class="nav-item">

--- a/distributedsocialnetwork/templates/index.html
+++ b/distributedsocialnetwork/templates/index.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load markup_tags %}
 {% block nav-home %}
 <a class="nav-link active" href="{% url 'home' %}">Home</a>
 {% endblock  %}
@@ -28,37 +27,26 @@
     <div class="row p-2 m-2 justify-content-center">
         <a role="button" class="btn btn-lg btn-block btn-outline-primary" href="/friends">Friends</a>
     </div>
-    {%endif%}
+    {% endif %}
   </div>
-  <div class="col-8 stream bg-white pb-3" id="stream">
-    <div class="row p-2 justify-content-left">
-      <h2>Stream</h2>
-    </div>
-    {% for post in posts %}
-    <div class="card m-2 post">
-      <div class="card-body">
-        <a class="card-title" href="{{ post.source }}">
-          <div class="row-12">
-            <h5>{{ post.title }}</h5>
+  <div class="col-8 stream bg-white pb-3">
+    <ul id="tabs" class="nav nav-tabs" data-tabs="tabs">
+      <li class="nav-item stream-tab-item">
+        <a href="#stream" class="nav-link active" data-toggle="tab"><h2>Stream</h2></a>
+      </li>
+      <li class="nav-item stream-tab-item">
+        <a href="#explore" class="nav-link" data-toggle="tab" onclick="get_foreign_posts()"><h2>Explore</h2></a>
+      </li>
+    </ul>
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="stream">
+          {% include "stream.html" %}
+      </div>
+      <div class="tab-pane fade" id="explore">
+          <div id="foreign_posts">
           </div>
-        </a>
-        <h6 class="card-subtitle mb-2 text-muted">{{ post.description }}</h6>
-        {% if post.contentType == 'text/markdown' %}
-        <div class="markdown-content col-6">{{ post.content | apply_markup:"markdown" |  truncatechars_html:500}}</div>
-        {% elif post.contentType == 'image/jpeg;base64' %}
-        <div class="card-text"><img src="data:image/jpeg;base64,{{ post.content }}"></div>
-        {% elif post.contentType == 'image/png;base64' %}
-        <div class="card-text"><img src="data:image/png;base64,{{ post.content }}"></div>
-        {% else %}
-        <p class="card-text">{{ post.content | truncatechars:500}}</p>
-        {% endif %}
-      </div>
-      <div class="card-footer text-muted text-right p-2">
-        <a href="{{post.author.url}}"><p class="m-0">{{ post.author.displayName }}</p></a>
-        <p class="small m-0">{{ post.published }}</p>
       </div>
     </div>
-    {% endfor %}
   </div>
   <div class="col text-right sidebar bg-light">
     <div class="row justify-content-center">
@@ -78,4 +66,16 @@
     {% endfor %}
   </div>
 </div>
+
+<script>
+  function get_foreign_posts(){
+    xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        document.getElementById('foreign_posts').innerHTML = this.responseText;
+    };
+    xhttp.open("GET","/api/posts/foreign", true);
+    xhttp.send();
+  }
+  window.onload = get_foreign_posts;
+</script>
 {% endblock content %}

--- a/distributedsocialnetwork/templates/stream.html
+++ b/distributedsocialnetwork/templates/stream.html
@@ -1,0 +1,36 @@
+{% load markup_tags %}
+{% for post in posts %}
+<div class="card m-2 post">
+    <div class="card-body">
+        <a class="card-title" href="{{ post.source }}">
+            <div class="row-12">
+                <h5>{{ post.title }}</h5>
+            </div>
+        </a>
+        <h6 class="card-subtitle mb-2 text-muted">{{ post.description }}</h6>
+        {% if post.contentType == 'text/markdown' %}
+        <div class="markdown-content col-6">{{ post.content | apply_markup:"markdown" |  truncatechars_html:500}}</div>
+        {% elif post.contentType == 'image/jpeg;base64' %}
+        <div class="card-text"><img src="data:image/jpeg;base64,{{ post.content }}"></div>
+        {% elif post.contentType == 'image/png;base64' %}
+        <div class="card-text"><img src="data:image/png;base64,{{ post.content }}"></div>
+        {% else %}
+        <p class="card-text">{{ post.content | truncatechars:500}}</p>
+        {% endif %}
+    </div>
+    <div class="card-footer text-muted text-right p-2">
+        <a href="{{post.author.url}}"><p class="m-0">{{ post.author.displayName }}</p></a>
+        <p class="small m-0">{{ post.published }}</p>
+    </div>
+</div>
+{% endfor %}
+<!-- Placeholder card if there are no posts to see -->
+{% if posts.count == 0 %}
+<div class="card m-2 post">
+  <div class="card-body">
+    <div class="card-title">
+      <h5>There are no posts available 😞</h5>
+    </div>
+  </div>
+</div>
+{% endif %}


### PR DESCRIPTION
Split the homepage into two tabs, 'Stream' and 'Explore'. The Explore tab pulls foreign posts via an ajax call to a new api endpoint, /posts/foreign