### PR TITLE
Author endpoint and hostname changes

### DIFF
--- a/distributedsocialnetwork/api/tests.py
+++ b/distributedsocialnetwork/api/tests.py
@@ -1125,13 +1125,13 @@ class AuthorDetail(APITestCase):
         url = '/api/author/' + self.author1.id[29:]
         response = self.client.get(url)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["author"]["id"], self.author1.id)
+        self.assertEquals(response.data["id"], self.author1.id)
         self.assertEquals(
-            response.data["author"]["displayName"], self.author1.displayName)
-        self.assertEquals(response.data["author"]["email"], self.author1.email)
-        self.assertEquals(response.data["author"]["url"], self.author1.url)
-        self.assertEquals(response.data["author"]["host"], self.author1.host)
-        self.assertEquals(response.data["author"]
+            response.data["displayName"], self.author1.displayName)
+        self.assertEquals(response.data["email"], self.author1.email)
+        self.assertEquals(response.data["url"], self.author1.url)
+        self.assertEquals(response.data["host"], self.author1.host)
+        self.assertEquals(response.data
                           ["github"], self.author1.github)
 
     def test_get_invalid_uuid(self):

--- a/distributedsocialnetwork/api/views.py
+++ b/distributedsocialnetwork/api/views.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from django.shortcuts import get_object_or_404, render
 import urllib
 from django.conf import settings
+from distributedsocialnetwork.views import url_convert, source_convert
 import uuid
 import requests
 # Create your views here.
@@ -160,7 +161,7 @@ class ForeignPosts(APIView):
         posts = Post.objects.filter(visibility="PUBLIC").exclude(
             origin__icontains=settings.FORMATTED_HOST_NAME)
         context = {}
-        context["posts"] = posts
+        context["posts"] = source_convert(posts)
         return render(request, 'stream.html', context)
 
 # ====== /api/posts/<post_id> ======

--- a/distributedsocialnetwork/api/views.py
+++ b/distributedsocialnetwork/api/views.py
@@ -1050,7 +1050,5 @@ class AuthorDetail(APIView):
         for friend in Friend.objects.get_friends(author):
             friend_dicts.append(AuthorSerializer(friend).data)
         author_dict["friends"] = friend_dicts
-        response = {
-            "author": author_dict
-        }
+        response = author_dict
         return Response(response, status=status.HTTP_200_OK)

--- a/distributedsocialnetwork/author/views.py
+++ b/distributedsocialnetwork/author/views.py
@@ -8,6 +8,7 @@ from .models import Author
 from .retrieval import get_detailed_author
 from post.models import Post
 from friend.models import Friend, Follower
+from distributedsocialnetwork.views import source_convert
 
 
 def index(request):
@@ -145,6 +146,8 @@ def view_author(request, pk):
             context['posts'] = Post.objects.filter(
                 author=context['author'].id, visibility="PUBLIC")
             context["user"] = None
+    # Convert posts to have working links
+    context['posts'] = source_convert(context['posts'])
     if request.method == "POST":
         # A post here is when we are going to send a friend request from the currently authenticated user
         if request.user.is_authenticated:

--- a/distributedsocialnetwork/distributedsocialnetwork/settings.py
+++ b/distributedsocialnetwork/distributedsocialnetwork/settings.py
@@ -154,7 +154,7 @@ ENV = environ.Env(
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
 HOST_NAME = ENV('HOST_NAME')
-FORMATTED_HOST_NAME = 'http://' + HOST_NAME + '/'
+FORMATTED_HOST_NAME = 'http://' + HOST_NAME + '/api/'
 
 # Heroku
 django_heroku.settings(locals())

--- a/distributedsocialnetwork/distributedsocialnetwork/templatetags/extras.py
+++ b/distributedsocialnetwork/distributedsocialnetwork/templatetags/extras.py
@@ -1,0 +1,10 @@
+from django import template
+
+# These are custom template filters.
+register = template.Library()
+
+
+@register.filter(name='author_url_converter')
+def author_url_converter(value):
+    # We take in the value, in this case the url of our author, and then return the one that takes them to the front-facing profile page.
+    return value.split('api/')[0] + value.split('api/')[-1]

--- a/distributedsocialnetwork/distributedsocialnetwork/views.py
+++ b/distributedsocialnetwork/distributedsocialnetwork/views.py
@@ -21,6 +21,9 @@ def source_convert(queryset):
     for obj in queryset:
         obj.source = obj.source.split(
             'api/')[0] + obj.source.split('api/')[-1]
+        # Also, fix the author url
+        obj.author.url = obj.author.url.split(
+            'api/')[0] + obj.author.url.split('api/')[-1]
     return queryset
 
 
@@ -52,7 +55,4 @@ def index(request):
         posts = Post.objects.filter(
             visibility="PUBLIC", origin__icontains=settings.FORMATTED_HOST_NAME)
     context['posts'] = source_convert(posts)
-    for post in context['posts']:
-        post.author.url = post.author.url.split(
-            'api/')[0] + post.author.url.split('api/')[-1]
     return render(request, 'index.html', context)

--- a/distributedsocialnetwork/distributedsocialnetwork/views.py
+++ b/distributedsocialnetwork/distributedsocialnetwork/views.py
@@ -11,19 +11,22 @@ from friend.retrieval import update_friends_list
 def url_convert(queryset):
     # Given queryset of authors, returns the same queryset with all urls set properly
     for obj in queryset:
-        obj.url = obj.url.split(
-            'api/')[0] + obj.url.split('api/')[-1]
+        if 'api/' in obj.url:
+            obj.url = obj.url.split(
+                'api/')[0] + obj.url.split('api/')[-1]
     return queryset
 
 
 def source_convert(queryset):
     # Same as above, but for source
     for obj in queryset:
-        obj.source = obj.source.split(
-            'api/')[0] + obj.source.split('api/')[-1]
-        # Also, fix the author url
-        obj.author.url = obj.author.url.split(
-            'api/')[0] + obj.author.url.split('api/')[-1]
+        if 'api/' in obj.source:
+            obj.source = obj.source.split(
+                'api/')[0] + obj.source.split('api/')[-1]
+            # Also, fix the author url
+            if 'api/' in obj.author.url:
+                obj.author.url = obj.author.url.split(
+                    'api/')[0] + obj.author.url.split('api/')[-1]
     return queryset
 
 

--- a/distributedsocialnetwork/distributedsocialnetwork/views.py
+++ b/distributedsocialnetwork/distributedsocialnetwork/views.py
@@ -8,6 +8,22 @@ from author.retrieval import get_detailed_author, get_visible_posts
 from friend.retrieval import update_friends_list
 
 
+def url_convert(queryset):
+    # Given queryset of authors, returns the same queryset with all urls set properly
+    for obj in queryset:
+        obj.url = obj.url.split(
+            'api/')[0] + obj.url.split('api/')[-1]
+    return queryset
+
+
+def source_convert(queryset):
+    # Same as above, but for source
+    for obj in queryset:
+        obj.source = obj.source.split(
+            'api/')[0] + obj.source.split('api/')[-1]
+    return queryset
+
+
 def index(request):
     context = {}
     # get_public_posts()
@@ -16,7 +32,7 @@ def index(request):
     # We only want the authors from our server to be featured in the "featured authors" section
     authors = Author.objects.filter(
         host=settings.FORMATTED_HOST_NAME, is_node=False, is_staff=False)
-    context['authors'] = authors
+    context['authors'] = url_convert(authors)
     if request.user.is_authenticated:
         # get_visible_posts(request.user.id)
         # We give them more results on the main stream
@@ -35,5 +51,8 @@ def index(request):
     else:
         posts = Post.objects.filter(
             visibility="PUBLIC", origin__icontains=settings.FORMATTED_HOST_NAME)
-    context['posts'] = posts
+    context['posts'] = source_convert(posts)
+    for post in context['posts']:
+        post.author.url = post.author.url.split(
+            'api/')[0] + post.author.url.split('api/')[-1]
     return render(request, 'index.html', context)

--- a/distributedsocialnetwork/friend/views.py
+++ b/distributedsocialnetwork/friend/views.py
@@ -6,8 +6,12 @@ from friend.models import FollowerManager, FriendManager, Follower
 from author.models import Author
 from django.conf import settings
 from .retrieval import send_friend_request
+# This is a tool to convert urls into links that work
+from distributedsocialnetwork.views import url_convert
 
 # Create your views here.
+
+# This one is not a view.
 
 
 def show_friends(request):
@@ -20,9 +24,9 @@ def show_friends(request):
     followers = FollowerManager.get_followers('', user_id)
     following = FollowerManager.get_following('', user_id)
     friends = FriendManager.get_friends('', user_id)
-    context['friends'] = friends
-    context['followers'] = followers
-    context['following'] = following
+    context['friends'] = url_convert(friends)
+    context['followers'] = url_convert(followers)
+    context['following'] = url_convert(following)
 
     # non-fff
     # Everyone now excludes nodes, admins
@@ -41,11 +45,10 @@ def show_friends(request):
     for author in foreign:
         if author not in fff:
             other_foreign.append(author)
-    context['local'] = local
-    context['other_local'] = other_local
-    context['foreign'] = foreign
-    context['other_foreign'] = other_foreign
-
+    context['local'] = url_convert(local)
+    context['other_local'] = url_convert(other_local)
+    context['foreign'] = url_convert(foreign)
+    context['other_foreign'] = url_convert(other_foreign)
     context['hostname'] = settings.FORMATTED_HOST_NAME
     return render(request, 'friends.html', context)
 

--- a/distributedsocialnetwork/friend/views.py
+++ b/distributedsocialnetwork/friend/views.py
@@ -41,14 +41,22 @@ def show_friends(request):
     other_foreign = []
     for author in local:
         if author not in fff:
+            author.url = author.url.split(
+                'api/')[0] + author.url.split('api/')[-1]
             other_local.append(author)
     for author in foreign:
         if author not in fff:
+            author.url = author.url.split(
+                'api/')[0] + author.url.split('api/')[-1]
             other_foreign.append(author)
-    context['local'] = url_convert(local)
-    context['other_local'] = url_convert(other_local)
-    context['foreign'] = url_convert(foreign)
-    context['other_foreign'] = url_convert(other_foreign)
+    # context['local'] = url_convert(local)
+    # context['other_local'] = url_convert(other_local)
+    # context['foreign'] = url_convert(foreign)
+    # context['other_foreign'] = url_convert(other_foreign)
+    context['local'] = local
+    context['other_local'] = other_local
+    context['foreign'] = foreign
+    context['other_foreign'] = other_foreign
     context['hostname'] = settings.FORMATTED_HOST_NAME
     return render(request, 'friends.html', context)
 

--- a/distributedsocialnetwork/friend/views.py
+++ b/distributedsocialnetwork/friend/views.py
@@ -30,29 +30,20 @@ def show_friends(request):
 
     # non-fff
     # Everyone now excludes nodes, admins
-    local = Author.objects.filter(
-        is_node=False, is_staff=False, host=settings.FORMATTED_HOST_NAME)
+    local = url_convert(Author.objects.filter(
+        is_node=False, is_staff=False, host=settings.FORMATTED_HOST_NAME))
     # Foreign is everyone who is not local
-    foreign = Author.objects.filter(is_node=False, is_staff=False).exclude(
-        host=settings.FORMATTED_HOST_NAME)
-    # TODO: add a separate section for displaying foreign authors
+    foreign = url_convert(Author.objects.filter(is_node=False, is_staff=False).exclude(
+        host=settings.FORMATTED_HOST_NAME))
     fff = set([current_user] + followers + following + friends)
     other_local = []
     other_foreign = []
     for author in local:
         if author not in fff:
-            author.url = author.url.split(
-                'api/')[0] + author.url.split('api/')[-1]
             other_local.append(author)
     for author in foreign:
         if author not in fff:
-            author.url = author.url.split(
-                'api/')[0] + author.url.split('api/')[-1]
             other_foreign.append(author)
-    # context['local'] = url_convert(local)
-    # context['other_local'] = url_convert(other_local)
-    # context['foreign'] = url_convert(foreign)
-    # context['other_foreign'] = url_convert(other_foreign)
     context['local'] = local
     context['other_local'] = other_local
     context['foreign'] = foreign

--- a/distributedsocialnetwork/post/views.py
+++ b/distributedsocialnetwork/post/views.py
@@ -8,6 +8,7 @@ from author.models import Author
 import datetime
 import uuid
 from .retrieval import get_detailed_post, post_foreign_comment, get_comments
+from distributedsocialnetwork.views import url_convert, source_convert
 
 # Create your views here.
 
@@ -28,7 +29,10 @@ def create_post(request):
                 'posts/' + str(new_post.id)
             new_post.source = new_post.origin
             new_post.save()
-            return redirect(new_post.source)
+            # We want to redirect them to the page where they can see it
+            new_post_page = new_post.source.split(
+                'api/')[0] + new_post.source.split('api/')[-1]
+            return redirect(new_post_page)
 
     else:
         form = PostCreationForm()
@@ -53,18 +57,26 @@ def view_post(request, pk):
                     res = post_foreign_comment(new_comment)
                     if (res.status_code == 201):
                         new_comment.save()
-                        return redirect(new_comment.post_id.source)
+                        # We want to redirect them to the post page
+                        post_page = new_comment.post_id.source.split(
+                            'api/')[0] + new_comment.post_id.source.split('api/')[-1]
+                        return redirect(post_page)
                     else:
                         form = PostCommentForm()
                         form.non_field_errors = "Comment failed to post, please try again."
                 else:
                     new_comment.save()
-                    return redirect(new_comment.post_id.source)
+                    post_page = new_comment.post_id.source.split(
+                        'api/')[0] + new_comment.post_id.source.split('api/')[-1]
+                    return redirect(post_page)
             else:
                 form = PostCommentForm()
     else:
         form = PostCommentForm()
     context['post'] = get_detailed_post(post_id=pk)
+    # So that clicking the title of the post does not take you to the wrong page
+    context['post'].source = context['post'].source.split(
+        'api/')[0] + context['post'].source.split('api/')[-1]
     # Now that we have the post in the backend, we have to verify that the current user can see it.
     post_visibility = context["post"].visibility
     if post_visibility != "PUBLIC":
@@ -117,7 +129,9 @@ def edit_post(request, pk):
                 'posts/' + str(new_post.id)
             new_post.source = new_post.origin
             new_post.save()
-            return redirect(new_post.source)
+            post_page = new_post.source.split(
+                'api/')[0] + new_post.source.split('api/')[-1]
+            return redirect(post_page)
 
     else:
         form = PostCreationForm(instance=post)

--- a/distributedsocialnetwork/templates/base.html
+++ b/distributedsocialnetwork/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load extras %}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -40,7 +41,8 @@
 			</li>
 			{% if request.user.is_authenticated %}
 			<li class="nav-item">
-				{% block nav-profile%}<a class="nav-link" href="{{request.user.url}}">{{ request.user|title }}</a>{% endblock %}
+				<!-- Modification of the user's URL in here so that we can link them to the correct page-->
+				{% block nav-profile%}<a class="nav-link" href="{{ request.user.url | author_url_converter }}">{{ request.user|title }}</a>{% endblock %}
 			</li>
 			<li class="nav-item">
 				<!-- We should be logging out via POST, so this is a simple form to do so -->


### PR DESCRIPTION
* Changed hostname in settings to include /api/ so backend better matches the spec. **This may break some of team 4's endpoints so we will need to test with them before pushing this to master.**
* Changed the frontend links such that they don't lead to the Django Rest Framework pages.
* Changed /author/{author_id} endpoint to match the docs closer (per request of Team 4)