### PR TITLE
Frnt/227 improve post creation images

### DIFF
--- a/distributedsocialnetwork/post/templates/create.html
+++ b/distributedsocialnetwork/post/templates/create.html
@@ -70,7 +70,13 @@
         document.getElementById("id_image").src = e.target.result;
       }); 
     
-      FR.readAsDataURL( this.files[0] );
+      let file = this.files[0];
+      if (file && $("#id_contentType").val().includes(file.type)) {
+        FR.readAsDataURL( this.files[0] );
+      }else{
+        //Not a valid filetype!
+        $("#id_imageUpload").val("");
+      }
     }
   }
 
@@ -101,7 +107,5 @@
     create_file_uploader();
     $("#id_contentType").change(toggle_image_content);
   }
-
-  
 </script>
 {% endblock %}

--- a/distributedsocialnetwork/post/templates/create.html
+++ b/distributedsocialnetwork/post/templates/create.html
@@ -21,20 +21,20 @@
           {field.help_text}}
         </small>
         {% endif %}
+        {% for error in field.errors %}
+          <p style="color: red;" class="blah">
+            {{error}}
+          </p>
+        {% endfor %}
       </div>
-      {% endfor %} {% for field in postCreationForm %}
-      {% for error in field.errors %}
-      <p style="color: red;">
-        {{error}}
-      </p>
-      {% endfor %} {% endfor %} {% if postCreationForm.non_field_errors %}
+      {% endfor %} 
+      {% if postCreationForm.non_field_errors %}
       <div style="color: red">
         <p>
           {{postCreationForm.non_field_errors}}
         </p>
       </div>
       {% endif %}
-    
       <button type="submit" class="btn btn-lg btn-block btn-outline-primary">Submit Post</button>
     </form>
   </div>
@@ -55,5 +55,53 @@
       document.getElementById("id_visibleTo").removeAttribute("disabled");
     }
   };
+
+  //Thanks to user Roko C. Buljan answering user bombastic's question on StackOverflow: https://stackoverflow.com/a/17711190
+  function readFile() {
+    if (this.files && this.files[0]) {
+    
+      var FR= new FileReader();
+    
+      FR.addEventListener("load", function(e) {
+        let code = e.target.result;
+        code = code.replace('data:image/png;base64,','');
+        code = code.replace('data:image/jpeg;base64,','');
+        document.getElementById("id_content").value = code;
+        document.getElementById("id_image").src = e.target.result;
+      }); 
+    
+      FR.readAsDataURL( this.files[0] );
+    }
+  }
+
+  function create_file_uploader() {
+    $("#id_content").after("<input id=\"id_imageUpload\" type='file'>");
+    $("#id_content").after("<img id=\"id_image\" alt=\"Upload An Image\" style=\"max-width: 400px; max-height: 500px;\">");
+    $("#id_imageUpload").change(readFile);
+
+    toggle_image_content();
+  };
+
+  function toggle_image_content() {
+    let elem = $("#id_contentType");
+    if (elem.val() =='image/png;base64' || elem.val() == 'image/jpeg;base64') {
+      $("#id_content").hide();
+      $("#id_imageUpload").show();
+      $("#id_image").show();
+      //Set the image src to the value of the content field.
+      $("#id_image").attr("src","data:" + elem.val() + "," + $("#id_content").val());
+    }else{
+      $('#id_content').show();
+      $("#id_imageUpload").hide();
+      $("#id_image").hide();
+    }
+  };
+
+  window.onload = function () {
+    create_file_uploader();
+    $("#id_contentType").change(toggle_image_content);
+  }
+
+  
 </script>
 {% endblock %}

--- a/distributedsocialnetwork/post/templates/edit_post.html
+++ b/distributedsocialnetwork/post/templates/edit_post.html
@@ -72,7 +72,13 @@
         document.getElementById("id_image").src = e.target.result;
       }); 
     
-      FR.readAsDataURL( this.files[0] );
+      let file = this.files[0];
+      if (file && $("#id_contentType").val().includes(file.type)) {
+        FR.readAsDataURL( this.files[0] );
+      }else{
+        //Not a valid filetype!
+        $("#id_imageUpload").val("");
+      }
     }
   }
 

--- a/distributedsocialnetwork/post/templates/edit_post.html
+++ b/distributedsocialnetwork/post/templates/edit_post.html
@@ -22,13 +22,14 @@
           {field.help_text}}
         </small>
         {% endif %}
+        {% for error in field.errors %}
+          <p style="color: red;">
+            {{error}}
+          </p>
+        {% endfor %}
       </div>
-      {% endfor %} {% for field in postCreationForm %}
-      {% for error in field.errors %}
-      <p style="color: red;">
-        {{error}}
-      </p>
-      {% endfor %} {% endfor %} {% if postCreationForm.non_field_errors %}
+      {% endfor %} 
+      {% if postCreationForm.non_field_errors %}
       <div style="color: red">
         <p>
           {{postCreationForm.non_field_errors}}
@@ -56,5 +57,50 @@
       document.getElementById("id_visibleTo").removeAttribute("disabled");
     }
   };
+
+  //Thanks to user Roko C. Buljan answering user bombastic's question on StackOverflow: https://stackoverflow.com/a/17711190
+  function readFile() {
+    if (this.files && this.files[0]) {
+    
+      var FR= new FileReader();
+    
+      FR.addEventListener("load", function(e) {
+        let code = e.target.result;
+        code = code.replace('data:image/png;base64,','');
+        code = code.replace('data:image/jpeg;base64,','');
+        document.getElementById("id_content").value = code;
+        document.getElementById("id_image").src = e.target.result;
+      }); 
+    
+      FR.readAsDataURL( this.files[0] );
+    }
+  }
+
+  function create_file_uploader() {
+    $("#id_content").after("<input id=\"id_imageUpload\" type='file'>");
+    $("#id_content").after("<img id=\"id_image\" alt=\"Upload An Image\" style=\"max-width: 400px; max-height: 500px;\">");
+    $("#id_imageUpload").change(readFile);
+
+    toggle_image_content();
+  };
+
+  function toggle_image_content() {
+    let elem = $("#id_contentType");
+    if (elem.val() =='image/png;base64' || elem.val() == 'image/jpeg;base64') {
+      $("#id_content").hide();
+      $("#id_imageUpload").show();
+      $("#id_image").show();
+      $("#id_image").attr("src","data:" + elem.val() + "," + $("#id_content").val());
+    }else{
+      $('#id_content').show();
+      $("#id_imageUpload").hide();
+      $("#id_image").hide();
+    }
+  };
+
+  window.onload = function () {
+    create_file_uploader();
+    $("#id_contentType").change(toggle_image_content);
+  }
 </script>
 {% endblock %}

--- a/distributedsocialnetwork/post/views.py
+++ b/distributedsocialnetwork/post/views.py
@@ -28,6 +28,8 @@ def create_post(request):
             new_post.origin = settings.FORMATTED_HOST_NAME + \
                 'posts/' + str(new_post.id)
             new_post.source = new_post.origin
+            if new_post.contentType == 'image/png;base64' or new_post.contentType == 'image/jpeg;base64':
+                new_post.unlisted = True
             new_post.save()
             # We want to redirect them to the page where they can see it
             new_post_page = new_post.source.split(
@@ -135,6 +137,11 @@ def edit_post(request, pk):
             new_post.origin = settings.FORMATTED_HOST_NAME + \
                 'posts/' + str(new_post.id)
             new_post.source = new_post.origin
+            if new_post.contentType == 'image/png;base64' or new_post.contentType == 'image/jpeg;base64':
+                new_post.unlisted = True
+            else:
+                # This post might have been unlisted before editing, make sure it isn't now.
+                new_post.unlisted = False
             new_post.save()
             post_page = new_post.source.split(
                 'api/')[0] + new_post.source.split('api/')[-1]


### PR DESCRIPTION
Add a file upload input to post create/edit pages. This is only displayed when contentType is png or jpeg. Also modified Post views to set posts with png or jpeg content types to unlisted.