### PR TITLE
Now pulls in comments from team 6 if we have seen the author already.

### DIFF
--- a/distributedsocialnetwork/post/retrieval.py
+++ b/distributedsocialnetwork/post/retrieval.py
@@ -288,7 +288,6 @@ def get_comments(pk):
         if response.status_code == 200:
             comments_json = response.json()
             for comment in comments_json["comments"]:
-                comment = sanitize_comment(comment)
                 try:
                     comment = sanitize_comment(comment)
                     if len(Author.objects.filter(id=comment["author"]["id"])) != 1:


### PR DESCRIPTION
No longer crashes the page when parsing goes wrong. Also translates their int IDs into UUIDs if needed, much like what we do for their posts.

Until they fix their endpoint (which they are aware of, and supposedly the info is valid internally), this is the best we can do.